### PR TITLE
fix setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+	"plover[gui_qt]>=4.0.0.dev10",
+	"setuptools>=38.2.4",
+	"wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,6 @@ keywords = plover plover_plugin
 
 [options]
 zip_safe = True
-setup_requires = 
-    setuptools >= 30.3.0
 install_requires =
     plover >= 4.0.0.dev8
 packages = 

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,15 @@
 
 from setuptools import setup
 
-from plover_build_utils.setup import BuildPy, BuildUi
+from plover_build_utils.setup import BuildPy, BuildUi, Develop
 
 BuildPy.build_dependencies.append('build_ui')
 BuildUi.hooks = ['plover_build_utils.pyqt:fix_icons']
+Develop.build_dependencies.append('build_py')
 CMDCLASS = {
     'build_py': BuildPy,
     'build_ui': BuildUi,
+    'develop': Develop,
 }
 
 setup(cmdclass=CMDCLASS)


### PR DESCRIPTION
* fix build requirements: add `pyproject.toml`, and ensure PyQt5 is available (by depending on `plover[gui_qt]`)
* fix editable installation: ensure the `develop` command generate the UI resources